### PR TITLE
Improvement to path selector popup error handling

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,0 +1,15 @@
+# These are supported funding model platforms
+
+github: # Replace with up to 4 GitHub Sponsors-enabled usernames e.g., [user1, user2]
+patreon: # Replace with a single Patreon username
+open_collective: # Replace with a single Open Collective username
+ko_fi: davidca6
+tidelift: # Replace with a single Tidelift platform-name/package-name e.g., npm/babel
+community_bridge: # Replace with a single Community Bridge project-name e.g., cloud-foundry
+liberapay: # Replace with a single Liberapay username
+issuehunt: # Replace with a single IssueHunt username
+lfx_crowdfunding: # Replace with a single LFX Crowdfunding project-name e.g., cloud-foundry
+polar: # Replace with a single Polar username
+buy_me_a_coffee: # Replace with a single Buy Me a Coffee username
+thanks_dev: # Replace with a single thanks.dev username
+custom: # Replace with up to 4 custom sponsorship URLs e.g., ['link1', 'link2']

--- a/OpenCaptions.py
+++ b/OpenCaptions.py
@@ -403,20 +403,44 @@ def main():
     subtotext_combo = None
     subtotext_template_combo = None
 
+    def prompt_for_path(dialog_func, **kwargs):
+        try:
+            root.update_idletasks()
+            root.lift()
+            return dialog_func(parent=root, **kwargs)
+        except Exception as error:
+            status_var.set("Could not open file picker. Paste the path manually.")
+            print(f"File dialog error: {error}")
+            return ""
+
     def select_srt_file(entry):
         if entry not in track_entries:
             return
-        path = filedialog.askopenfilename(title="Select SRT File", filetypes=[("SRT files", "*.srt"), ("All files", "*.*")])
+        path = prompt_for_path(
+            filedialog.askopenfilename,
+            title="Select SRT File",
+            filetypes=[("SRT files", "*.srt"), ("All files", "*.*")],
+        )
         if path:
             entry["srt_var"].set(path)
 
     def select_export_file():
-        path = filedialog.asksaveasfilename(title="Export SRT File", defaultextension=".srt", filetypes=[("SRT files", "*.srt"), ("All files", "*.*")])
+        path = prompt_for_path(
+            filedialog.asksaveasfilename,
+            title="Export SRT File",
+            defaultextension=".srt",
+            filetypes=[("SRT files", "*.srt"), ("All files", "*.*")],
+        )
         if path:
             export_path_var.set(path)
 
     def select_exportsub_file():
-        path = filedialog.asksaveasfilename(title="Export SRT File", defaultextension=".srt", filetypes=[("SRT files", "*.srt"), ("All files", "*.*")])
+        path = prompt_for_path(
+            filedialog.asksaveasfilename,
+            title="Export SRT File",
+            defaultextension=".srt",
+            filetypes=[("SRT files", "*.srt"), ("All files", "*.*")],
+        )
         if path:
             exportsub_path_var.set(path)
 


### PR DESCRIPTION
Improvement of error handling for the path selector popup

- more exception handling, so at minimum there should be an error message in the Resolve terminal when it doesn't work (could potentially point to the issue)
- force lift (focus the window) in case it's opening behind the Resolve window

Related to #4, but will improve reliability of the path selector overall.